### PR TITLE
Adds the dependency to ragg

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,2 @@
+#lang setup/infotab
+(define deps (list "ragg"))


### PR DESCRIPTION
Also, you may need to modify the README so it says: 

```
$ raco pkg install --deps search-ask minipascal

...

#lang racket
(require planet2)
(install "minipascal" #:deps 'search-ask)
```
