### PR TITLE
added newline and back ticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ The compiler more traditional, it expands the whole
 Pascal program in one go.
 
 To switch from the full compiler to the simple one,
-add 'simple' to the #lang line. That is, the lines:
+add `simple` to the `#lang` line. That is, the lines:
+
     #lang minipascal
     #lang minipascal simple
 use the full and simple compiler respectively.


### PR DESCRIPTION
added newline and back ticks to indicate code - I think the newline was intended by the author as the changed lines had the tab at the beginning, but code doesn't appear unless preceeded by a blank line.  The back ticks are just a pretty way to inline `code`.
