### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,13 +2,11 @@
 (define collection 'multi)
 (define version    "1.0")
 (define deps '("ragg" "base"
-                      "parser-tools-lib"
-                      "unstable-list-lib"))
+                      "parser-tools-lib"))
 
 
 (define build-deps '("base"
                       "parser-tools-lib"
-                      "unstable-list-lib"
                       "at-exp-lib"
                       "rackunit-lib"
                       "scribble-lib"

--- a/minipascal/compiler-simple.rkt
+++ b/minipascal/compiler-simple.rkt
@@ -22,8 +22,7 @@
 (require syntax/parse)
 
 ; A few other helpers are used:
-(require unstable/list ; for map2
-         racket/match
+(require racket/match
          racket/syntax)
 
 ;;; Syntax used in the compiler

--- a/minipascal/compiler.rkt
+++ b/minipascal/compiler.rkt
@@ -19,8 +19,7 @@
 (require syntax/parse)
 
 ; A few other helpers are used:
-(require unstable/list ; for map2
-         racket/match
+(require racket/match
          racket/syntax)
 
 ;;; Syntax used in the compiler
@@ -790,7 +789,9 @@
   (syntax-parse stx
     [(_ id "(" expr0 (~seq "," expr) ... ")")
      (def exprs (syntax->list #'(expr0 expr ...)))
-     (def (es types) (map2 compile-expression exprs))
+     (def (es types) (for/lists (es types)
+                       ([e (in-list exprs)])
+                       (compile-expression e)))
      (define info (lookup-var #'id))
      (unless info
        (raise-syntax-error 'application "name unbound" #'id))


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.
